### PR TITLE
feat(retriever): forward optional prefetch/query to the Query API

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -80,3 +80,26 @@ export const qdrantRetriever = qdrantRetrieverRef('collectionName', 'displayName
 ```
 
 You can refer to [Retrieval-augmented generation](https://firebase.google.com/docs/genkit/rag) for a general discussion on indexers and retrievers.
+
+### Score boosting / fusion (Query API passthrough)
+
+The retriever options accept optional `query` and `prefetch` fields that are forwarded to the Qdrant [Query API](https://qdrant.tech/documentation/concepts/search/#query-api). When `query` is set, the retriever runs a two-stage request: the embedded vector becomes a `prefetch` (overridable via `prefetch`) and `query` reranks the candidates. This enables server-side formula boosting, fusion (RRF), and multi-stage prefetch without leaving the retriever.
+
+```js
+const docs = await ai.retrieve({
+  retriever: qdrantRetriever,
+  query: 'wireless headphones',
+  options: {
+    k: 20,
+    // Rerank prefetched candidates by a formula mixing the vector score with a
+    // payload signal (e.g. boost in-stock items).
+    query: {
+      formula: {
+        sum: ['$score', { mult: [0.2, 'in_stock'] }],
+      },
+    },
+  },
+});
+```
+
+When neither `query` nor `prefetch` is provided, behaviour is unchanged — a plain vector query.

--- a/js/README.md
+++ b/js/README.md
@@ -16,17 +16,17 @@ To use this plugin, specify it when you call `configureGenkit()`:
 import { qdrant } from 'genkitx-qdrant';
 
 const ai = genkit({
-    plugins: [
-        qdrant([
-            {
-                embedder: googleAI.embedder('text-embedding-004'),
-                collectionName: 'collectionName',
-                clientParams: {
-                    url: 'http://localhost:6333',
-                }
-            }
-        ]),
-    ],
+  plugins: [
+    qdrant([
+      {
+        embedder: googleAI.embedder('text-embedding-004'),
+        collectionName: 'collectionName',
+        clientParams: {
+          url: 'http://localhost:6333',
+        },
+      },
+    ]),
+  ],
 });
 ```
 
@@ -51,7 +51,7 @@ addition, there are a few optional parameters:
   metadataPayloadKey: 'metadata';
   ```
 
-- `dataTypePayloadKey`: Name of the payload filed with the document datatype. Defaults to "_content_type".
+- `dataTypePayloadKey`: Name of the payload filed with the document datatype. Defaults to "\_content_type".
 
   ```js
   dataTypePayloadKey: '_datatype';
@@ -76,14 +76,17 @@ export const qdrantIndexer = qdrantIndexerRef('collectionName', 'displayName');
 
 ```js
 // To export a retriever:
-export const qdrantRetriever = qdrantRetrieverRef('collectionName', 'displayName');
+export const qdrantRetriever = qdrantRetrieverRef(
+  'collectionName',
+  'displayName',
+);
 ```
 
 You can refer to [Retrieval-augmented generation](https://firebase.google.com/docs/genkit/rag) for a general discussion on indexers and retrievers.
 
-### Score boosting / fusion (Query API passthrough)
+### Score boosting / fusion
 
-The retriever options accept optional `query` and `prefetch` fields that are forwarded to the Qdrant [Query API](https://qdrant.tech/documentation/concepts/search/#query-api). When `query` is set, the retriever runs a two-stage request: the embedded vector becomes a `prefetch` (overridable via `prefetch`) and `query` reranks the candidates. This enables server-side formula boosting, fusion (RRF), and multi-stage prefetch without leaving the retriever.
+The retriever options accept optional `query` and `prefetch` fields, forwarded to the Qdrant [Query API](https://qdrant.tech/documentation/concepts/search/#query-api). When `query` is set, the embedded vector becomes a `prefetch` (overridable via `prefetch`) and `query` reranks the candidates, enabling formula boosting, fusion (RRF), and multi-stage prefetch. Omit both for a plain vector query.
 
 ```js
 const docs = await ai.retrieve({
@@ -91,15 +94,8 @@ const docs = await ai.retrieve({
   query: 'wireless headphones',
   options: {
     k: 20,
-    // Rerank prefetched candidates by a formula mixing the vector score with a
-    // payload signal (e.g. boost in-stock items).
-    query: {
-      formula: {
-        sum: ['$score', { mult: [0.2, 'in_stock'] }],
-      },
-    },
+    // Boost in-stock items.
+    query: { formula: { sum: ['$score', { mult: [0.2, 'in_stock'] }] } },
   },
 });
 ```
-
-When neither `query` nor `prefetch` is provided, behaviour is unchanged — a plain vector query.

--- a/js/package.json
+++ b/js/package.json
@@ -13,7 +13,7 @@
     "genai",
     "generative-ai"
   ],
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "commonjs",
   "scripts": {
     "check": "tsc",

--- a/js/src/index.mts
+++ b/js/src/index.mts
@@ -20,11 +20,7 @@ const QdrantRetrieverOptionsSchema = CommonRetrieverOptionsSchema.extend({
   k: z.number().default(10),
   filter: FilterType.optional(),
   scoreThreshold: z.number().optional(),
-  // Optional Query API passthrough. When `query` is set, the retriever runs a
-  // two-stage request: the embedded vector becomes a `prefetch` (overridable
-  // via `prefetch`) and `query` reranks the candidates — enabling server-side
-  // formula boosting, fusion (RRF), and multi-stage prefetch. When omitted,
-  // behaviour is unchanged (a plain vector query).
+  // Optional Query API passthrough for formula boosting / fusion (RRF).
   prefetch: PrefetchType.optional(),
   query: QueryType.optional(),
 });
@@ -160,31 +156,19 @@ export function configureQdrantRetriever<
         options: embedderOptions,
       });
       const embedding = queryEmbeddings[0].embedding;
-      const queryRequest = options.query
-        ? {
-            // Two-stage: prefetch candidates by vector, then rerank with `query`
-            // (formula / fusion / …). `prefetch` is overridable; defaults to the
-            // embedded vector limited to `k`.
-            prefetch: options.prefetch ?? {
-              query: embedding,
-              limit: options.k,
-            },
-            query: options.query,
-            limit: options.k,
-            filter: options.filter,
-            with_payload: [contentKey, metadataKey, dataTypeKey],
-            with_vector: false,
-          }
-        : {
-            // Default: plain vector query (unchanged behaviour).
-            query: embedding,
-            limit: options.k,
-            filter: options.filter,
-            score_threshold: options.scoreThreshold,
-            with_payload: [contentKey, metadataKey, dataTypeKey],
-            with_vector: false,
-          };
-      const results = (await client.query(collectionName, queryRequest)).points;
+      const results = (
+        await client.query(collectionName, {
+          prefetch: options.query
+            ? (options.prefetch ?? { query: embedding, limit: options.k })
+            : undefined,
+          query: options.query ?? embedding,
+          limit: options.k,
+          filter: options.filter,
+          score_threshold: options.scoreThreshold,
+          with_payload: [contentKey, metadataKey, dataTypeKey],
+          with_vector: false,
+        })
+      ).points;
       const documents = results.map((result) => {
         const content = result.payload?.[contentKey] ?? '';
         const metadata = {

--- a/js/src/index.mts
+++ b/js/src/index.mts
@@ -12,11 +12,21 @@ import { genkitPlugin } from 'genkit/plugin';
 import { v5 as uuidv5 } from 'uuid';
 
 const FilterType: z.ZodType<Schemas['Filter']> = z.any();
+const PrefetchType: z.ZodType<Schemas['Prefetch'] | Schemas['Prefetch'][]> =
+  z.any();
+const QueryType: z.ZodType<Schemas['Query']> = z.any();
 
 const QdrantRetrieverOptionsSchema = CommonRetrieverOptionsSchema.extend({
   k: z.number().default(10),
   filter: FilterType.optional(),
   scoreThreshold: z.number().optional(),
+  // Optional Query API passthrough. When `query` is set, the retriever runs a
+  // two-stage request: the embedded vector becomes a `prefetch` (overridable
+  // via `prefetch`) and `query` reranks the candidates — enabling server-side
+  // formula boosting, fusion (RRF), and multi-stage prefetch. When omitted,
+  // behaviour is unchanged (a plain vector query).
+  prefetch: PrefetchType.optional(),
+  query: QueryType.optional(),
 });
 
 export const QdrantIndexerOptionsSchema = z.null().optional();
@@ -74,7 +84,10 @@ interface QdrantPluginParams<E extends z.ZodTypeAny = z.ZodTypeAny> {
  * @param params.displayName  A display name for the retriever. If not specified, the default label will be `Qdrant - <collectionName>`
  * @returns A reference to a Qdrant retriever.
  */
-export const qdrantRetrieverRef = (collectionName: string, displayName: string | null = null) => {
+export const qdrantRetrieverRef = (
+  collectionName: string,
+  displayName: string | null = null,
+) => {
   return retrieverRef({
     name: `qdrant/${collectionName}`,
     info: {
@@ -91,7 +104,10 @@ export const qdrantRetrieverRef = (collectionName: string, displayName: string |
  * @param params.displayName  A display name for the indexer. If not specified, the default label will be `Qdrant - <collectionName>`
  * @returns A reference to a Qdrant indexer.
  */
-export const qdrantIndexerRef = (collectionName: string, displayName: string | null = null) => {
+export const qdrantIndexerRef = (
+  collectionName: string,
+  displayName: string | null = null,
+) => {
   return indexerRef({
     name: `qdrant/${collectionName}`,
     info: {
@@ -143,16 +159,32 @@ export function configureQdrantRetriever<
         content,
         options: embedderOptions,
       });
-      const results = (
-        await client.query(collectionName, {
-          query: queryEmbeddings[0].embedding,
-          limit: options.k,
-          filter: options.filter,
-          score_threshold: options.scoreThreshold,
-          with_payload: [contentKey, metadataKey, dataTypeKey],
-          with_vector: false,
-        })
-      ).points;
+      const embedding = queryEmbeddings[0].embedding;
+      const queryRequest = options.query
+        ? {
+            // Two-stage: prefetch candidates by vector, then rerank with `query`
+            // (formula / fusion / …). `prefetch` is overridable; defaults to the
+            // embedded vector limited to `k`.
+            prefetch: options.prefetch ?? {
+              query: embedding,
+              limit: options.k,
+            },
+            query: options.query,
+            limit: options.k,
+            filter: options.filter,
+            with_payload: [contentKey, metadataKey, dataTypeKey],
+            with_vector: false,
+          }
+        : {
+            // Default: plain vector query (unchanged behaviour).
+            query: embedding,
+            limit: options.k,
+            filter: options.filter,
+            score_threshold: options.scoreThreshold,
+            with_payload: [contentKey, metadataKey, dataTypeKey],
+            with_vector: false,
+          };
+      const results = (await client.query(collectionName, queryRequest)).points;
       const documents = results.map((result) => {
         const content = result.payload?.[contentKey] ?? '';
         const metadata = {


### PR DESCRIPTION
### What

Adds optional `prefetch` and `query` fields to `QdrantRetrieverOptionsSchema`, forwarded to the Qdrant Query API. When `query` is set, the retriever runs a two-stage request — the embedded vector becomes a `prefetch` (overridable via `prefetch`), and `query` reranks the candidates. This unlocks the Query API features the client already supports: `FormulaQuery` (server-side score boosting), `FusionQuery` (RRF / hybrid), and multi-stage `prefetch`.

Resolves #23.

### Why

The retriever was already on `client.query(...)` but only ever sent a bare vector — there was no way to use formula boosting or fusion without bypassing the plugin and calling the raw client (losing the embedding + `Document` mapping + tracing the plugin provides). This is the minimal change to expose that capability.

### Backward compatibility

**No behaviour change when the new fields are absent.** The retriever branches on `options.query`: when it's not set, the request is byte-for-byte identical to before (plain vector query with `score_threshold`). The boost path activates only on an explicit `query`. Every existing caller is unaffected.

### Design

The plugin forwards raw Query API objects (`prefetch` / `query`) rather than introducing a higher-level boost DSL — keeping it neutral and letting callers use the full Query API surface. This mirrors the spirit of #11 (score threshold passthrough).

### Example

```ts
const docs = await ai.retrieve({
  retriever: qdrantRetriever,
  query: 'wireless headphones',
  options: {
    k: 20,
    query: { formula: { sum: ['$score', { mult: [0.2, 'in_stock'] }] } },
  },
});
```

### Checks

- `npm run check` (tsc) — clean
- `prettier --check` on changed files — clean
- README updated with a "Score boosting / fusion" section

Happy to adjust the shape (e.g. a typed schema instead of `z.any()` passthrough) if you'd prefer — flagged that option in #23.
