### PR TITLE
feat(retriever): grouped retrieval via Qdrant Grouping API (groupBy/groupSize)

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -102,7 +102,7 @@ const docs = await ai.retrieve({
 
 ### Grouped retrieval (diversity)
 
-The retriever options accept an optional `groupBy` field (with optional `groupSize`), forwarded to the Qdrant [Grouping API](https://qdrant.tech/documentation/concepts/search/#grouping-api). When `groupBy` is set, results are grouped by that payload field and up to `groupSize` hits are returned per group (defaults to Qdrant's default of 3), across `k` groups. This diversifies results so a single over-represented group — e.g. one large document split into many chunks, or one dominant category — cannot crowd out the rest. Documents are returned as a flat list, group-ordered, with the group key exposed on each document's metadata as the reserved `_group` field (which overrides any same-named field in the document's own metadata). The `groupBy` field must be indexed. Note: re-sorting the returned documents by `_similarityScore` interleaves groups and undoes the diversity — keep the returned order to preserve grouping.
+Set the optional `groupBy` field (an indexed payload field) to use the Qdrant [Grouping API](https://qdrant.tech/documentation/concepts/search/#grouping-api). Qdrant returns up to `groupSize` hits per group (default 3) across `k` groups, so one over-represented group (a large document split into many chunks, say) can't crowd out the rest. The retriever flattens the groups in order and writes each group key to the document's `_group` metadata, so keep the returned order. Re-sorting by `_similarityScore` interleaves the groups.
 
 ```js
 const docs = await ai.retrieve({

--- a/js/README.md
+++ b/js/README.md
@@ -99,3 +99,22 @@ const docs = await ai.retrieve({
   },
 });
 ```
+
+### Grouped retrieval (diversity)
+
+The retriever options accept an optional `groupBy` field (with optional `groupSize`), forwarded to the Qdrant [Grouping API](https://qdrant.tech/documentation/concepts/search/#grouping-api). When `groupBy` is set, results are grouped by that payload field and up to `groupSize` hits are returned per group (defaults to Qdrant's default of 3), across `k` groups. This diversifies results so a single over-represented group — e.g. one large document split into many chunks, or one dominant category — cannot crowd out the rest. Documents are returned as a flat list, group-ordered, with the group key exposed on each document's metadata as the reserved `_group` field (which overrides any same-named field in the document's own metadata). The `groupBy` field must be indexed. Note: re-sorting the returned documents by `_similarityScore` interleaves groups and undoes the diversity — keep the returned order to preserve grouping.
+
+```js
+const docs = await ai.retrieve({
+  retriever: qdrantRetriever,
+  query: 'fire-rated pipe penetration',
+  options: {
+    k: 8, // up to 8 groups
+    groupBy: 'metadata.productFamily',
+    groupSize: 3, // up to 3 chunks per family
+    filter: {
+      must: [{ key: 'metadata.wallType', match: { value: 'flexible' } }],
+    },
+  },
+});
+```

--- a/js/package.json
+++ b/js/package.json
@@ -13,7 +13,7 @@
     "genai",
     "generative-ai"
   ],
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "commonjs",
   "scripts": {
     "check": "tsc",

--- a/js/src/index.mts
+++ b/js/src/index.mts
@@ -24,12 +24,23 @@ const QdrantRetrieverOptionsSchema: z.ZodObject<{
   scoreThreshold: z.ZodOptional<z.ZodNumber>;
   prefetch: z.ZodOptional<typeof PrefetchType>;
   query: z.ZodOptional<typeof QueryType>;
+  groupBy: z.ZodOptional<z.ZodString>;
+  groupSize: z.ZodOptional<z.ZodNumber>;
 }> = CommonRetrieverOptionsSchema.extend({
   k: z.number().default(10),
   filter: FilterType.optional(),
   scoreThreshold: z.number().optional(),
   prefetch: PrefetchType.optional(),
   query: QueryType.optional(),
+  // When set, results are grouped by this payload field (e.g. a document id or
+  // category) via the Qdrant Grouping API, returning up to `groupSize` hits per
+  // group. This diversifies results so a single over-represented group cannot
+  // crowd out others. The group key is exposed on each returned document's
+  // metadata as the reserved `_group` field (overrides any same-named field in
+  // the document's own metadata). Documents are still returned as a flat list.
+  groupBy: z.string().min(1).optional(),
+  // Max hits per group when `groupBy` is set. Defaults to 3 (Qdrant default).
+  groupSize: z.number().int().positive().optional(),
 });
 
 export const QdrantIndexerOptionsSchema = z.null().optional();
@@ -37,6 +48,9 @@ export const QdrantIndexerOptionsSchema = z.null().optional();
 const CONTENT_PAYLOAD_KEY = 'content';
 const METADATA_PAYLOAD_KEY = 'metadata';
 const CONTENT_TYPE_KEY = '_content_type';
+// Qdrant's own default for `group_size` when grouping; used to size the
+// default prefetch candidate pool so reranking can fill `k` groups.
+const DEFAULT_GROUP_SIZE = 3;
 
 /**
  * Parameters for the Qdrant plugin.
@@ -166,32 +180,82 @@ export function configureQdrantRetriever<
         options: embedderOptions,
       });
       const embedding = queryEmbeddings[0].embedding;
-      const results = (
-        await client.query(collectionName, {
-          prefetch: options.query
-            ? (options.prefetch ?? { query: embedding, limit: options.k })
-            : undefined,
-          query: options.query ?? embedding,
-          limit: options.k,
-          filter: options.filter,
-          score_threshold: options.scoreThreshold,
-          with_payload: [contentKey, metadataKey, dataTypeKey],
-          with_vector: false,
-        })
-      ).points;
-      const documents = results.map((result) => {
-        const content = result.payload?.[contentKey] ?? '';
+      const withPayload = [contentKey, metadataKey, dataTypeKey];
+      // Shared mapper for both the flat and grouped paths: a scored point
+      // (`{ payload, score }`) becomes a Genkit Document. `extraMetadata` lets
+      // the grouped path attach the group key.
+      const toDocument = (
+        point: { payload?: Record<string, unknown> | null; score?: number },
+        extraMetadata: Record<string, unknown> = {},
+      ) => {
+        const content = point.payload?.[contentKey] ?? '';
         const metadata = {
-          ...(result.payload?.[metadataKey] ?? {}),
-          _similarityScore: result.score,
+          ...((point.payload?.[metadataKey] as Record<string, unknown>) ?? {}),
+          _similarityScore: point.score,
+          ...extraMetadata,
         } as Record<string, unknown>;
-        const dataType = result.payload?.[dataTypeKey] ?? 'text';
+        const dataType = point.payload?.[dataTypeKey] ?? 'text';
         return Document.fromData(
           content as string,
           dataType as string,
-          metadata as Record<string, unknown>,
+          metadata,
         ).toJSON();
-      });
+      };
+
+      // Prefetch/query reranking (formula boosting, fusion) applies to both the
+      // flat and grouped paths: when `query` is set the embedded vector becomes
+      // a prefetch (overridable) and `query` reranks the candidates.
+      // For grouping, `k` counts groups (not points), so the default prefetch
+      // must pull enough candidates to populate `k` groups of `groupSize` —
+      // otherwise reranking sees too few points to fill the groups.
+      const defaultPrefetchLimit = options.groupBy
+        ? options.k * (options.groupSize ?? DEFAULT_GROUP_SIZE)
+        : options.k;
+      const prefetch = options.query
+        ? (options.prefetch ?? {
+            query: embedding,
+            limit: defaultPrefetchLimit,
+          })
+        : undefined;
+      const query = options.query ?? embedding;
+
+      let documents: ReturnType<typeof toDocument>[];
+      if (options.groupBy) {
+        // Grouping API: up to `groupSize` hits per `groupBy` value, `k` groups.
+        // Diversifies results across the facet so one over-represented group
+        // (e.g. a large multi-chunk document, or a dominant category) cannot
+        // crowd out the rest. The group key is exposed on each document's
+        // metadata as `_group`; documents are still returned as a flat list.
+        const groups = (
+          await client.queryGroups(collectionName, {
+            prefetch,
+            query,
+            group_by: options.groupBy,
+            group_size: options.groupSize,
+            limit: options.k,
+            filter: options.filter,
+            score_threshold: options.scoreThreshold,
+            with_payload: withPayload,
+            with_vector: false,
+          })
+        ).groups;
+        documents = groups.flatMap((group) =>
+          group.hits.map((hit) => toDocument(hit, { _group: group.id })),
+        );
+      } else {
+        const results = (
+          await client.query(collectionName, {
+            prefetch,
+            query,
+            limit: options.k,
+            filter: options.filter,
+            score_threshold: options.scoreThreshold,
+            with_payload: withPayload,
+            with_vector: false,
+          })
+        ).points;
+        documents = results.map((result) => toDocument(result));
+      }
       return {
         documents,
       };

--- a/js/src/index.mts
+++ b/js/src/index.mts
@@ -32,14 +32,9 @@ const QdrantRetrieverOptionsSchema: z.ZodObject<{
   scoreThreshold: z.number().optional(),
   prefetch: PrefetchType.optional(),
   query: QueryType.optional(),
-  // When set, results are grouped by this payload field (e.g. a document id or
-  // category) via the Qdrant Grouping API, returning up to `groupSize` hits per
-  // group. This diversifies results so a single over-represented group cannot
-  // crowd out others. The group key is exposed on each returned document's
-  // metadata as the reserved `_group` field (overrides any same-named field in
-  // the document's own metadata). Documents are still returned as a flat list.
+  // Payload field to group results by (Qdrant Grouping API). The group key is
+  // set on each document's metadata as `_group`.
   groupBy: z.string().min(1).optional(),
-  // Max hits per group when `groupBy` is set. Defaults to 3 (Qdrant default).
   groupSize: z.number().int().positive().optional(),
 });
 
@@ -48,8 +43,6 @@ export const QdrantIndexerOptionsSchema = z.null().optional();
 const CONTENT_PAYLOAD_KEY = 'content';
 const METADATA_PAYLOAD_KEY = 'metadata';
 const CONTENT_TYPE_KEY = '_content_type';
-// Qdrant's own default for `group_size` when grouping; used to size the
-// default prefetch candidate pool so reranking can fill `k` groups.
 const DEFAULT_GROUP_SIZE = 3;
 
 /**
@@ -181,9 +174,7 @@ export function configureQdrantRetriever<
       });
       const embedding = queryEmbeddings[0].embedding;
       const withPayload = [contentKey, metadataKey, dataTypeKey];
-      // Shared mapper for both the flat and grouped paths: a scored point
-      // (`{ payload, score }`) becomes a Genkit Document. `extraMetadata` lets
-      // the grouped path attach the group key.
+      // Maps a scored point to a Document; `extraMetadata` carries the group key.
       const toDocument = (
         point: { payload?: Record<string, unknown> | null; score?: number },
         extraMetadata: Record<string, unknown> = {},
@@ -202,12 +193,8 @@ export function configureQdrantRetriever<
         ).toJSON();
       };
 
-      // Prefetch/query reranking (formula boosting, fusion) applies to both the
-      // flat and grouped paths: when `query` is set the embedded vector becomes
-      // a prefetch (overridable) and `query` reranks the candidates.
-      // For grouping, `k` counts groups (not points), so the default prefetch
-      // must pull enough candidates to populate `k` groups of `groupSize` —
-      // otherwise reranking sees too few points to fill the groups.
+      // When grouping, `k` is the group count, so size the default prefetch for
+      // `k * groupSize` candidates.
       const defaultPrefetchLimit = options.groupBy
         ? options.k * (options.groupSize ?? DEFAULT_GROUP_SIZE)
         : options.k;
@@ -221,11 +208,6 @@ export function configureQdrantRetriever<
 
       let documents: ReturnType<typeof toDocument>[];
       if (options.groupBy) {
-        // Grouping API: up to `groupSize` hits per `groupBy` value, `k` groups.
-        // Diversifies results across the facet so one over-represented group
-        // (e.g. a large multi-chunk document, or a dominant category) cannot
-        // crowd out the rest. The group key is exposed on each document's
-        // metadata as `_group`; documents are still returned as a flat list.
         const groups = (
           await client.queryGroups(collectionName, {
             prefetch,

--- a/js/src/index.mts
+++ b/js/src/index.mts
@@ -32,8 +32,6 @@ const QdrantRetrieverOptionsSchema: z.ZodObject<{
   scoreThreshold: z.number().optional(),
   prefetch: PrefetchType.optional(),
   query: QueryType.optional(),
-  // Payload field to group results by (Qdrant Grouping API). The group key is
-  // set on each document's metadata as `_group`.
   groupBy: z.string().min(1).optional(),
   groupSize: z.number().int().positive().optional(),
 });
@@ -174,7 +172,7 @@ export function configureQdrantRetriever<
       });
       const embedding = queryEmbeddings[0].embedding;
       const withPayload = [contentKey, metadataKey, dataTypeKey];
-      // Maps a scored point to a Document; `extraMetadata` carries the group key.
+
       const toDocument = (
         point: { payload?: Record<string, unknown> | null; score?: number },
         extraMetadata: Record<string, unknown> = {},


### PR DESCRIPTION
Adds optional `groupBy` (+ `groupSize`) retriever options. When `groupBy` is set, the retriever uses the Qdrant [Grouping API](https://qdrant.tech/documentation/concepts/search/#grouping-api) (`queryGroups`) to return up to `groupSize` hits per group across `k` groups, then flattens to the usual `Document[]` with the group key on each document's metadata as the reserved `_group` field.

### Why
A plain top-k vector search can be dominated by a single over-represented group — e.g. one large document split into many chunks, or one dominant category — starving rarer-but-relevant groups so they never appear in results at all. Grouping returns the best hits *per group*, so every group passing the filter is represented. This is the standard fix when the diversity axis is a known payload facet (document id, product family, category).

### Behaviour
- `groupBy` is **optional and backward-compatible**: when unset, the existing `query`/`prefetch` path is unchanged.
- Prefetch/query reranking (formula boosting, fusion) is forwarded to **both** the flat and grouped paths.
- The point→`Document` mapping is refactored into a single shared helper reused by both paths (no behavioural change to the flat path).
- `groupBy` must reference an indexed payload field. Documents are returned as a flat, group-ordered list; `_group` exposes the group key.

### Validation
- `npm run check` (tsc) — passes.
- `npm run format:check` (prettier) — clean.
- Verified against the Qdrant `QueryGroupsRequest` / `GroupsResult` types in `@qdrant/js-client-rest`.

Docs added under **Usage → Grouped retrieval (diversity)** in the README.