### PR TITLE
Set copyright holder in LICENSE files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-  Copyright [yyyy] [name of copyright owner]
+  Copyright 2026 Qdrant Solutions GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replaces the Apache 2.0 placeholder line with Copyright 2026 Qdrant Solutions GmbH.

Files changed:
- LICENSE